### PR TITLE
Single-page UX, compact header, creative credits, and SEO enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,58 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Markdown Live - Free Online Markdown Editor & Instant Preview</title>
     <meta
       name="description"
-      content="Markdown Live — a beautiful, fast, and local-first markdown editor with instant preview."
+      content="Markdown Live is a free online markdown editor with instant preview, autosave, GitHub-flavored markdown support, and local-first privacy."
     />
-    <title>Markdown Live</title>
+    <meta
+      name="keywords"
+      content="markdown editor, markdown live preview, online markdown editor, markdown, github flavored markdown, md editor"
+    />
+    <meta name="author" content="Yash Soni" />
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+    <link rel="canonical" href="https://markdownlive.app/" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Markdown Live - Free Online Markdown Editor & Instant Preview" />
+    <meta
+      property="og:description"
+      content="Write markdown and get instant preview in a fast, local-first editor built for creators and developers."
+    />
+    <meta property="og:url" content="https://markdownlive.app/" />
+    <meta property="og:image" content="/assets/banner.png" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Markdown Live - Free Online Markdown Editor & Instant Preview" />
+    <meta
+      name="twitter:description"
+      content="Free markdown editor with live preview, local autosave, import/export, and dark mode."
+    />
+    <meta name="twitter:image" content="/assets/banner.png" />
+
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "Markdown Live",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Any",
+        "url": "https://markdownlive.app/",
+        "description": "A fast, local-first markdown editor with instant preview and GitHub-flavored markdown support.",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "creator": {
+          "@type": "Person",
+          "name": "Yash Soni"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,10 +83,19 @@ export default function App() {
         </section>
       </main>
 
-      <footer className="footer">
-        <a href="https://iyashsoni.github.io" target="_blank" rel="noreferrer">
-          Built with ❤️ in India by Yash Soni iyashsoni.github.io
-        </a>
+      <footer className="footer" aria-label="Credits">
+        <p>
+          🏆 <strong>Yash Soni</strong> • The Markdown Maestro • Building notes at lightspeed.
+        </p>
+        <div className="credit-links">
+          <a href="https://iyashsoni.github.io" target="_blank" rel="noreferrer">
+            Official Site
+          </a>
+          <span className="dot" aria-hidden>
+            ✦
+          </span>
+          <span className="hall-of-fame">Founder, Markdown Live Hall of Fame</span>
+        </div>
       </footer>
     </div>
   );

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -16,13 +16,13 @@ export default function Toolbar({
         </span>
         <div>
           <h1>Markdown Live</h1>
-          <p>Beautiful, elegant and blazing fast</p>
+          <p>Lightning-fast markdown workspace</p>
         </div>
       </div>
 
       <div className="toolbar-controls">
-        <label htmlFor="md-filename" className="field">
-          File
+        <label htmlFor="md-filename" className="field field-inline">
+          <span className="field-label">File</span>
           <input
             id="md-filename"
             value={fileName}
@@ -31,23 +31,29 @@ export default function Toolbar({
           />
         </label>
 
-        <div className="actions">
+        <div className="actions actions-primary">
           <button type="button" onClick={onImport}>
             Import
           </button>
-          <button type="button" onClick={onCopy}>
-            Copy
-          </button>
           <button type="button" onClick={onDownload}>
-            Export .md
-          </button>
-          <button type="button" className="danger" onClick={onClear}>
-            Reset
+            Export
           </button>
           <button type="button" onClick={onThemeToggle}>
-            {isDark ? "Light" : "Dark"}
+            {isDark ? "☀ Light" : "🌙 Dark"}
           </button>
         </div>
+
+        <details className="more-menu">
+          <summary>More</summary>
+          <div className="more-menu-panel" role="menu" aria-label="More actions">
+            <button type="button" onClick={onCopy}>
+              Copy markdown
+            </button>
+            <button type="button" className="danger" onClick={onClear}>
+              Reset content
+            </button>
+          </div>
+        </details>
       </div>
     </header>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,18 +4,27 @@
   font-weight: 400;
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  overflow: hidden;
+}
 
 body {
   margin: 0;
-  min-height: 100vh;
   background: #090d1a;
 }
 
 .app {
-  min-height: 100vh;
+  height: 100vh;
   display: grid;
-  grid-template-rows: auto auto 1fr auto;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  overflow: hidden;
 }
 
 .theme-dark {
@@ -31,117 +40,279 @@ body {
 .toolbar {
   display: flex;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem 1.25rem;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 1rem;
   backdrop-filter: blur(8px);
   border-bottom: 1px solid #2d3d70;
 }
 
-.brand { display: flex; gap: .75rem; align-items: center; }
-.brand h1 { margin: 0; font-size: 1.25rem; }
-.brand p { margin: 0; opacity: .8; font-size: .9rem; }
-.brand-badge { font-size: 1.4rem; }
-
-.toolbar-controls { display: flex; gap: .75rem; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
-.field { display: grid; font-size: .8rem; gap: .3rem; }
-.field input {
-  border-radius: .65rem;
-  border: 1px solid #4c61a7;
-  padding: .45rem .6rem;
-  min-width: 9rem;
+.brand {
+  display: flex;
+  gap: 0.65rem;
+  align-items: center;
 }
 
-.actions { display: flex; flex-wrap: wrap; gap: .45rem; }
-button {
+.brand h1 {
+  margin: 0;
+  font-size: 1.08rem;
+  line-height: 1.1;
+}
+
+.brand p {
+  margin: 0;
+  opacity: 0.8;
+  font-size: 0.78rem;
+}
+
+.brand-badge {
+  font-size: 1.25rem;
+}
+
+.toolbar-controls {
+  display: flex;
+  gap: 0.55rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.field {
+  display: grid;
+  font-size: 0.76rem;
+  gap: 0.15rem;
+}
+
+.field-inline .field-label {
+  opacity: 0.85;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.field input {
+  border-radius: 0.6rem;
+  border: 1px solid #4c61a7;
+  padding: 0.34rem 0.55rem;
+  min-width: 7.5rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+button,
+.more-menu summary {
   border: 1px solid #4c61a7;
   background: #182758;
   color: #e8eefc;
-  border-radius: .7rem;
-  padding: .45rem .7rem;
+  border-radius: 0.65rem;
+  padding: 0.35rem 0.58rem;
+  font-size: 0.82rem;
   cursor: pointer;
+  list-style: none;
 }
-.theme-light button { background: #d8e4ff; color: #102a5c; }
-button:hover { transform: translateY(-1px); }
-button.danger { border-color: #a74c63; background: #5b2034; }
+
+.more-menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.theme-light button,
+.theme-light .more-menu summary {
+  background: #d8e4ff;
+  color: #102a5c;
+}
+
+button:hover,
+.more-menu summary:hover {
+  transform: translateY(-1px);
+}
+
+button.danger {
+  border-color: #a74c63;
+  background: #5b2034;
+}
+
+.more-menu {
+  position: relative;
+}
+
+.more-menu-panel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.35rem);
+  display: grid;
+  gap: 0.35rem;
+  min-width: 10rem;
+  padding: 0.4rem;
+  border: 1px solid #4c61a7;
+  border-radius: 0.75rem;
+  background: #0f1a3f;
+  z-index: 2;
+}
+
+.theme-light .more-menu-panel {
+  background: #edf3ff;
+}
 
 .stats {
   display: flex;
   gap: 1rem;
   flex-wrap: wrap;
-  padding: .75rem 1.25rem;
+  padding: 0.55rem 1rem;
   border-bottom: 1px solid #2d3d70;
-  font-size: .9rem;
+  font-size: 0.86rem;
 }
-.notice { font-weight: 700; color: #7ce9ff; }
-.theme-light .notice { color: #0f5db1; }
+
+.notice {
+  font-weight: 700;
+  color: #7ce9ff;
+}
+
+.theme-light .notice {
+  color: #0f5db1;
+}
 
 .workspace {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-  padding: 1rem;
+  gap: 0.75rem;
+  padding: 0.75rem;
   min-height: 0;
+  overflow: hidden;
 }
 
 .panel {
   border: 1px solid #324882;
-  border-radius: 1rem;
+  border-radius: 0.9rem;
   overflow: hidden;
   background: rgba(11, 19, 43, 0.8);
   display: flex;
   flex-direction: column;
   min-height: 0;
 }
-.theme-light .panel { background: rgba(255,255,255,.8); }
+
+.theme-light .panel {
+  background: rgba(255, 255, 255, 0.85);
+}
+
 .panel h2 {
   margin: 0;
   font-size: 1rem;
-  padding: .75rem 1rem;
+  padding: 0.7rem 1rem;
   border-bottom: 1px solid #324882;
 }
 
 #md-textarea {
   width: 100%;
-  min-height: 380px;
-  resize: vertical;
+  height: 100%;
+  min-height: 0;
+  flex: 1;
+  resize: none;
+  overflow: auto;
   border: 0;
   padding: 1rem;
   background: transparent;
   color: inherit;
   font: 500 15px/1.6 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
-#md-textarea:focus { outline: none; }
+
+#md-textarea:focus {
+  outline: none;
+}
 
 .markdown-body {
   overflow: auto;
   padding: 1rem 1.2rem;
 }
-.markdown-body img { max-width: 100%; border-radius: .75rem; }
+
+.markdown-body img {
+  max-width: 100%;
+  border-radius: 0.75rem;
+}
+
 .markdown-body pre {
   overflow: auto;
-  padding: .8rem;
-  border-radius: .65rem;
+  padding: 0.8rem;
+  border-radius: 0.65rem;
   background: #040814;
 }
-.markdown-body code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+
+.markdown-body code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
 .markdown-body blockquote {
   border-left: 3px solid #61dafb;
   margin: 0;
-  padding: .2rem 1rem;
-  opacity: .95;
+  padding: 0.2rem 1rem;
+  opacity: 0.95;
 }
-.markdown-body table { border-collapse: collapse; }
+
+.markdown-body table {
+  border-collapse: collapse;
+}
+
 .markdown-body th,
-.markdown-body td { border: 1px solid #5f74b6; padding: .4rem .55rem; }
+.markdown-body td {
+  border: 1px solid #5f74b6;
+  padding: 0.4rem 0.55rem;
+}
 
 .footer {
-  padding: .9rem 1.25rem 1.25rem;
+  padding: 0.5rem 1rem 0.65rem;
+  border-top: 1px solid #2d3d70;
   text-align: center;
+  background: linear-gradient(90deg, rgba(97, 218, 251, 0.08), rgba(255, 215, 96, 0.08));
 }
-.footer a { color: inherit; font-weight: 700; }
 
-.hidden-file-input { display: none; }
+.footer p {
+  margin: 0;
+  font-size: 0.86rem;
+}
+
+.credit-links {
+  margin-top: 0.15rem;
+  display: inline-flex;
+  gap: 0.45rem;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: center;
+  font-size: 0.8rem;
+}
+
+.credit-links a {
+  color: inherit;
+  font-weight: 700;
+}
+
+.hall-of-fame {
+  opacity: 0.92;
+  font-weight: 600;
+}
+
+.hidden-file-input {
+  display: none;
+}
+
+@media (max-width: 1100px) {
+  .toolbar {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .toolbar-controls {
+    width: 100%;
+    justify-content: center;
+  }
+}
 
 @media (max-width: 900px) {
-  .workspace { grid-template-columns: 1fr; }
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .brand p {
+    display: none;
+  }
 }


### PR DESCRIPTION
### Motivation
- Turn the app into a true single-page shell so the browser page never scrolls and Editor/Preview panes manage their own content scrolling.
- Reduce header clutter by surfacing high-frequency actions and moving secondary actions into a contextual menu for a cleaner, compact toolbar.
- Make the credits/footer more distinctive and brand-forward rather than a single link.
- Improve discoverability by adding richer SEO metadata and structured data to help search engines and social previews.

### Description
- Enforced single-page layout and locked page-level scrolling by updating `html`, `body`, `#root`, and `.app` sizing and overflow rules in `src/styles.css`, and made the editor textarea and preview article handle internal scrolling.
- Redesigned the header in `src/components/Toolbar.jsx` to tighten spacing/typography, keep primary actions (`Import`, `Export`, `Theme`) visible, and move secondary actions (`Copy`, `Reset`) into a `More` details menu.
- Replaced the simple footer link with a creative credits block in `src/App.jsx` that spotlights the creator and includes stylized credit links and a “hall of fame” label, with supporting styles in `src/styles.css`.
- Added SEO improvements in `index.html` including a descriptive `title`, expanded `meta` description, `keywords`, `author`, `robots`, `canonical`, Open Graph and Twitter card tags, and a JSON-LD `WebApplication` schema to assist search engines and social previews.

### Testing
- Attempted `npm run build`, which failed because `vite` is not available in the environment (`sh: 1: vite: not found`).
- Attempted `npm ci`, which failed due to registry access errors (`403 Forbidden`) in this environment so dependencies could not be installed, preventing a full build/test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8e22794b08321885a0a837c1ed909)